### PR TITLE
Update github urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ webrick:
     Access-Control-Allow-Origin: "*"
 
 # Theme settings
-site_author: Carlos Pereira Atencio
-repo_url: 'https://github.com/carlosperate/jekyll-theme-rtd'
+site_author: Cinemataztic
+repo_url: "https://github.com/cinemataztic/jekyll-theme-rtd"
 edit_on_github: true
 github_docs_folder: false
 sticky_navigation: true

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -20,7 +20,7 @@
       {%- if site.edit_on_github != false and page and page.name !=
       "search.html" %}
       <a
-        href="{{ site.repo_url | url }}/blob/master/{%- if site.github_docs_folder %}docs/{% endif %}{{ page.path }}"
+        href="{{ site.repo_url | url }}/blob/{%- if site.github_main_branch %}{{ site.github_main_branch }}{%- else %}master{% endif %}/{%- if site.github_docs_folder %}docs/{% endif %}{{ page.path }}"
         class="icon icon-github"
         target="_blank"
       >

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,10 @@
 title: Read The Docs Jekyll Theme
 description: Port of the Read the Docs theme to Jekyll to use with GitHub Pages.
-remote_theme: carlosperate/jekyll-theme-rtd
+remote_theme: cinemataztic/jekyll-theme-rtd
 
 # Theme settings:
-site_author: Carlos Pereira Atencio
-repo_url: "https://github.com/carlosperate/jekyll-theme-rtd"
+site_author: Cinemataztic
+repo_url: "https://github.com/cinemataztic/jekyll-theme-rtd"
 edit_on_github: true
 github_docs_folder: true
 sticky_navigation: true

--- a/docs/configuration/configyml.md
+++ b/docs/configuration/configyml.md
@@ -8,20 +8,19 @@ nav_order: 1
 
 The docs should have an index page.
 
-## Generic _config.yml configuration
-
+## Generic \_config.yml configuration
 
 ```yml
 title: Read The Docs Jekyll Theme
 description: Port of the Read the Docs theme to Jekyll to use with GitHub Pages.
 ```
 
-## Theme Specific Configuration 
+## Theme Specific Configuration
 
 ```yml
 # Specific to this theme
 site_author: Carlos Pereira Atencio
-repo_url: 'https://github.com/carlosperate/jekyll-theme-rtd'
+repo_url: "https://github.com/cinemataztic/jekyll-theme-rtd"
 edit_on_github: true
 github_docs_folder: true
 logo: 'https://your.url/image.png'


### PR DESCRIPTION
Update github urls. 
This fixes the broken urls on the edit on github buttons. 
If the published branch is different from `master` this can be set in the `site.github_main_branch` variable.
